### PR TITLE
Mode d'alimentation en performances élevées

### DIFF
--- a/sources/var/se3/unattended/install/os/netinst/se3w10s-3.cmd
+++ b/sources/var/se3/unattended/install/os/netinst/se3w10s-3.cmd
@@ -114,6 +114,10 @@ if exist Z:\scripts\perso.bat (
     echo Pas de commande personnalisee a lancer : pas de script Z:\scripts\perso.bat
 )
 
+::mise en place du mode d'alimentation peformances elevees
+echo Mise en place du plan d'alimentation : performances elevees
+powercfg /s 8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c
+
 :: accepter les drivers non signes
 echo Sous %WINVERS%, on accepte les drivers non signes.
 bcdedit.exe -set loadoptions DISABLE_INTEGRITY_CHECKS


### PR DESCRIPTION
Certaines machines se mettent en veille par défaut ce qui ne permet pas au se3 de les éteindre.
Le mode "performances élevées" évite ce problème.